### PR TITLE
Ssl

### DIFF
--- a/app.go
+++ b/app.go
@@ -29,5 +29,9 @@ func main() {
 	// SERVICES
 	log.Printf("... started ServeFile ...")
 	log.Printf("... serving %v on port %v ", cfg.APPNAME, cfg.HTTP_PORT)
-	g.Run(portOption);
+	if cfg.HTTP_PORT == "443" {
+		g.RunTLS(portOption, "certs/cert.pem", "certs/key.pem");
+	} else {
+		g.Run(portOption)
+	}
 }

--- a/dist-linux/cfg.json
+++ b/dist-linux/cfg.json
@@ -1,7 +1,7 @@
 {
    "appname" : "datawasher",
    "appversion" :  "0.0.1",
-   "http_port" : "8000",
+   "http_port" : 443",
    "server" : "0.0.0.0",
    "csv_file" : "data/contacts.csv"
 }


### PR DESCRIPTION
Adding optional SSL support. In cfg.json, if HTTP_PORT is set to 443, the server will run under TLS.
It will require the keys in "certs" subdirectory:

g.RunTLS(cfg.HTTP_PORT, "certs/cert.pem", "certs/key.pem")